### PR TITLE
fix(gentian): enable FUSE and propagate wrappers PATH to user services

### DIFF
--- a/system/nixos/customization/gentian.nix
+++ b/system/nixos/customization/gentian.nix
@@ -111,6 +111,25 @@ in {
 
   my.gui.enable = false;
 
+  # Allow users to mount FUSE filesystems (e.g. rclone/gdrive via home-manager).
+  programs.fuse.enable = true;
+
+  # Ensure user systemd services can locate the setuid fusermount3 wrapper.
+  #
+  # The user manager may start with a minimal PATH (only the bare systemd
+  # bin dir) before the PAM login environment is fully propagated.  Without
+  # /run/wrappers/bin in the PATH, rclone's bash wrapper prepends its own
+  # bundled fuse3 store path instead, handing the non-setuid fusermount3 to
+  # rclone — which then fails with EPERM when attempting the mount syscall.
+  #
+  # DefaultEnvironment in user.conf is read by every user manager instance
+  # at startup and passed as the default environment to all user services,
+  # so it takes effect even when the manager was started before a full login
+  # shell ran /etc/set-environment.
+  systemd.user.extraConfig = ''
+    DefaultEnvironment="PATH=/run/wrappers/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin"
+  '';
+
   my.server = {
     acme.staging = false;
     adminPubkey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIATV2dhRTcF0n4H2cGRixu1q/P8hlsDULqzk1BS1VtxB";


### PR DESCRIPTION
## Problem

User systemd services (e.g. a `rclone-gdrive` home-manager service for Google Drive mounts) fail with:

```
fusermount3: mount failed: Operation not permitted
```

The root cause is a two-step PATH problem:

1. **The user systemd manager starts with a minimal PATH.** On this server, `systemctl --user show-environment` shows `PATH=/nix/store/.../systemd/bin/` — only the bare systemd bin directory. This happens when the user manager is launched (e.g. by the first PAM session) before `/etc/set-environment` is sourced by a login shell and the full NixOS PATH (`/run/wrappers/bin:...`) is propagated back into the manager.

2. **rclone's nix package is a bash wrapper** that appends its own bundled fuse3 store path to `PATH`. With `/run/wrappers/bin` absent from the manager environment, rclone finds the **non-setuid** `fusermount3` from its bundled fuse3 path. A non-setuid `fusermount3` cannot perform the privileged `mount(2)` syscall and fails with `EPERM`.

The same login as an interactive shell works fine because `/etc/set-environment` is sourced early, placing `/run/wrappers/bin` before the bundled path.

## Fix

Two additions to `system/nixos/customization/gentian.nix`:

- **`programs.fuse.enable = true`** — makes FUSE support explicit and ensures `/etc/fuse.conf` is present (currently the wrapper exists due to transitive dependencies but the module is not declared).

- **`systemd.user.extraConfig` with `DefaultEnvironment`** — writes `/etc/systemd/user.conf` so every user manager instance (including those started before a login shell ran) passes `/run/wrappers/bin` at the front of `PATH` to all user services. The `DefaultEnvironment` key is the systemd-native mechanism for exactly this use case: setting a baseline environment for services when the ambient session environment is incomplete.